### PR TITLE
Fix live smoke follow-up fallbacks

### DIFF
--- a/src/api/gs25Handlers.ts
+++ b/src/api/gs25Handlers.ts
@@ -45,7 +45,7 @@ export async function handleGs25FindStores(c: ApiContext) {
       }
     }
 
-    const storeResult = await fetchGs25Stores(
+    let storeResult = await fetchGs25Stores(
       {
         serviceCode,
         latitude,
@@ -55,6 +55,38 @@ export async function handleGs25FindStores(c: ApiContext) {
         timeout: 20000,
       },
     );
+    let fallbackUsed = false;
+
+    if (storeResult.stores.length === 0 && typeof latitude === 'number' && typeof longitude === 'number') {
+      try {
+        const fallbackProduct = (await fetchGs25SearchProducts('오감자', { timeout: 20000 })).find(
+          (product) => product.itemCode.trim().length > 0,
+        );
+
+        if (fallbackProduct) {
+          const fallbackResult = await fetchGs25Stores(
+            {
+              serviceCode,
+              itemCode: fallbackProduct.itemCode,
+              realTimeStockYn: 'Y',
+              latitude,
+              longitude,
+              useCache: false,
+            },
+            {
+              timeout: 20000,
+            },
+          );
+
+          if (fallbackResult.stores.length > 0) {
+            storeResult = fallbackResult;
+            fallbackUsed = true;
+          }
+        }
+      } catch {
+        fallbackUsed = false;
+      }
+    }
 
     const selected = selectGs25StoresForKeyword(storeResult.stores, keyword, {
       relaxWhenEmpty: typeof latitude === 'number' && typeof longitude === 'number',
@@ -74,6 +106,7 @@ export async function handleGs25FindStores(c: ApiContext) {
             : null,
         cacheHit: storeResult.cacheHit,
         filterRelaxed: selected.filterRelaxed,
+        fallbackUsed,
         stores,
       },
       {

--- a/src/api/lottemartHandlers.ts
+++ b/src/api/lottemartHandlers.ts
@@ -36,6 +36,7 @@ export async function handleLotteMartFindStores(c: ApiContext) {
       {
         timeout: DEFAULT_LOTTEMART_TIMEOUT_MS,
         googleMapsApiKey: c.env?.GOOGLE_MAPS_API_KEY,
+        zyteApiKey: c.env?.ZYTE_API_KEY,
       },
     );
 
@@ -92,6 +93,7 @@ export async function handleLotteMartSearchProducts(c: ApiContext) {
       },
       {
         timeout: DEFAULT_LOTTEMART_TIMEOUT_MS,
+        zyteApiKey: c.env?.ZYTE_API_KEY,
       },
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ const createRegistry = (bindings?: AppBindings) => {
     () =>
       createLotteMartService({
         googleMapsApiKey: bindings?.GOOGLE_MAPS_API_KEY,
+        zyteApiKey: bindings?.ZYTE_API_KEY,
       }),
     createMegaboxService,
     () =>

--- a/src/services/gs25/tools/findNearbyStores.ts
+++ b/src/services/gs25/tools/findNearbyStores.ts
@@ -6,6 +6,7 @@ import * as z from 'zod';
 import type { McpToolResponse, ToolRegistration } from '../../../core/types.js';
 import {
   attachDistanceToGs25Stores,
+  fetchGs25SearchProducts,
   fetchGs25Stores,
   geocodeGs25Address,
   selectGs25StoresForKeyword,
@@ -50,7 +51,7 @@ async function findNearbyStores(args: FindNearbyStoresArgs): Promise<McpToolResp
     }
   }
 
-  const result = await fetchGs25Stores(
+  let result = await fetchGs25Stores(
     {
       serviceCode,
       latitude: resolvedLatitude,
@@ -60,6 +61,42 @@ async function findNearbyStores(args: FindNearbyStoresArgs): Promise<McpToolResp
       timeout: timeoutMs,
     },
   );
+  let fallbackUsed = false;
+
+  if (
+    result.stores.length === 0 &&
+    typeof resolvedLatitude === 'number' &&
+    typeof resolvedLongitude === 'number'
+  ) {
+    try {
+      const fallbackProduct = (await fetchGs25SearchProducts('오감자', { timeout: timeoutMs })).find(
+        (product) => product.itemCode.trim().length > 0,
+      );
+
+      if (fallbackProduct) {
+        const fallbackResult = await fetchGs25Stores(
+          {
+            serviceCode,
+            itemCode: fallbackProduct.itemCode,
+            realTimeStockYn: 'Y',
+            latitude: resolvedLatitude,
+            longitude: resolvedLongitude,
+            useCache: false,
+          },
+          {
+            timeout: timeoutMs,
+          },
+        );
+
+        if (fallbackResult.stores.length > 0) {
+          result = fallbackResult;
+          fallbackUsed = true;
+        }
+      }
+    } catch {
+      fallbackUsed = false;
+    }
+  }
 
   const selected = selectGs25StoresForKeyword(result.stores, keyword, {
     relaxWhenEmpty: typeof resolvedLatitude === 'number' && typeof resolvedLongitude === 'number',
@@ -87,6 +124,7 @@ async function findNearbyStores(args: FindNearbyStoresArgs): Promise<McpToolResp
             totalCount: result.totalCount,
             filteredCount: selected.stores.length,
             filterRelaxed: selected.filterRelaxed,
+            fallbackUsed,
             count: stores.length,
             stores,
           },

--- a/src/services/lottemart/index.ts
+++ b/src/services/lottemart/index.ts
@@ -17,15 +17,23 @@ const LOTTEMART_METADATA: ServiceMetadata = {
 class LotteMartService implements ServiceProvider {
   readonly metadata = LOTTEMART_METADATA;
 
-  constructor(private readonly googleMapsApiKey?: string) {}
+  constructor(
+    private readonly googleMapsApiKey?: string,
+    private readonly zyteApiKey?: string,
+  ) {}
 
   getTools(): ToolRegistration[] {
-    return [createFindNearbyStoresTool(this.googleMapsApiKey), createSearchProductsTool()];
+    return [
+      createFindNearbyStoresTool(this.googleMapsApiKey, this.zyteApiKey),
+      createSearchProductsTool(this.zyteApiKey),
+    ];
   }
 }
 
-export function createLotteMartService(options: { googleMapsApiKey?: string } = {}): ServiceProvider {
-  return new LotteMartService(options.googleMapsApiKey);
+export function createLotteMartService(
+  options: { googleMapsApiKey?: string; zyteApiKey?: string } = {},
+): ServiceProvider {
+  return new LotteMartService(options.googleMapsApiKey, options.zyteApiKey);
 }
 
 export * from './types.js';

--- a/src/services/lottemart/tools/findNearbyStores.ts
+++ b/src/services/lottemart/tools/findNearbyStores.ts
@@ -70,7 +70,7 @@ async function findNearbyStores(args: FindNearbyStoresArgs): Promise<McpToolResp
   };
 }
 
-export function createFindNearbyStoresTool(googleMapsApiKey?: string): ToolRegistration {
+export function createFindNearbyStoresTool(googleMapsApiKey?: string, zyteApiKey?: string): ToolRegistration {
   return {
     name: 'lottemart_find_nearby_stores',
     metadata: {
@@ -97,6 +97,7 @@ export function createFindNearbyStoresTool(googleMapsApiKey?: string): ToolRegis
       findNearbyStores({
         ...args,
         googleMapsApiKey: args.googleMapsApiKey || googleMapsApiKey,
+        zyteApiKey: args.zyteApiKey || zyteApiKey,
       })) as (
       args: unknown,
     ) => Promise<McpToolResponse>,

--- a/src/services/lottemart/tools/searchProducts.ts
+++ b/src/services/lottemart/tools/searchProducts.ts
@@ -66,7 +66,7 @@ async function searchProducts(args: SearchProductsArgs): Promise<McpToolResponse
   };
 }
 
-export function createSearchProductsTool(): ToolRegistration {
+export function createSearchProductsTool(zyteApiKey?: string): ToolRegistration {
   return {
     name: 'lottemart_search_products',
     metadata: {
@@ -85,6 +85,10 @@ export function createSearchProductsTool(): ToolRegistration {
           .describe(`요청 제한 시간(ms, 기본값: ${DEFAULT_LOTTEMART_TIMEOUT_MS})`),
       },
     },
-    handler: searchProducts as (args: unknown) => Promise<McpToolResponse>,
+    handler: ((args: SearchProductsArgs) =>
+      searchProducts({
+        ...args,
+        zyteApiKey: args.zyteApiKey || zyteApiKey,
+      })) as (args: unknown) => Promise<McpToolResponse>,
   };
 }

--- a/tests/services/gs25/tools/findNearbyStores.test.ts
+++ b/tests/services/gs25/tools/findNearbyStores.test.ts
@@ -144,4 +144,161 @@ describe('createFindNearbyStoresTool', () => {
 
     process.env.GOOGLE_MAPS_API_KEY = prevGoogleKey;
   });
+
+  it('좌표 기반 매장 조회가 비면 상품 재고 조회를 이용해 가까운 GS25 매장으로 대체한다', async () => {
+    const prevGoogleKey = process.env.GOOGLE_MAPS_API_KEY;
+    process.env.GOOGLE_MAPS_API_KEY = 'test-google-key';
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'OK',
+            results: [{ geometry: { location: { lat: 37.4979, lng: 127.0276 } } }],
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ stores: [] })))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            SearchQueryResult: {
+              Collection: [
+                {
+                  Documentset: {
+                    Document: [{ field: { itemCode: '8801117752804', itemName: '오감자' } }],
+                  },
+                },
+              ],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            stores: [
+              {
+                storeCode: 'near',
+                storeName: 'GS25강남메트로점',
+                storeAddress: '서울 강남구',
+                storeXCoordination: '127.0276',
+                storeYCoordination: '37.4979',
+              },
+            ],
+          }),
+        ),
+      );
+
+    const tool = createFindNearbyStoresTool();
+    const result = await tool.handler({ keyword: '강남', limit: 3 });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.fallbackUsed).toBe(true);
+    expect(parsed.count).toBe(1);
+    expect(parsed.stores[0].storeCode).toBe('near');
+
+    process.env.GOOGLE_MAPS_API_KEY = prevGoogleKey;
+  });
+
+  it('좌표 기반 매장 조회가 비고 fallback 상품 조회가 실패해도 빈 매장 결과를 반환한다', async () => {
+    const prevGoogleKey = process.env.GOOGLE_MAPS_API_KEY;
+    process.env.GOOGLE_MAPS_API_KEY = 'test-google-key';
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'OK',
+            results: [{ geometry: { location: { lat: 37.4979, lng: 127.0276 } } }],
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ stores: [] })))
+      .mockRejectedValueOnce(new Error('product search unavailable'));
+
+    const tool = createFindNearbyStoresTool();
+    const result = await tool.handler({ keyword: '강남', limit: 3 });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.fallbackUsed).toBe(false);
+    expect(parsed.count).toBe(0);
+
+    process.env.GOOGLE_MAPS_API_KEY = prevGoogleKey;
+  });
+
+  it('fallback 상품 후보가 없으면 빈 매장 결과를 반환한다', async () => {
+    const prevGoogleKey = process.env.GOOGLE_MAPS_API_KEY;
+    process.env.GOOGLE_MAPS_API_KEY = 'test-google-key';
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'OK',
+            results: [{ geometry: { location: { lat: 37.4979, lng: 127.0276 } } }],
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ stores: [] })))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            SearchQueryResult: {
+              Collection: [{ Documentset: { Document: [{ field: { itemCode: '', itemName: '오감자' } }] } }],
+            },
+          }),
+        ),
+      );
+
+    const tool = createFindNearbyStoresTool();
+    const result = await tool.handler({ keyword: '강남', limit: 3 });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.fallbackUsed).toBe(false);
+    expect(parsed.count).toBe(0);
+
+    process.env.GOOGLE_MAPS_API_KEY = prevGoogleKey;
+  });
+
+  it('fallback 상품 재고 조회도 비면 빈 매장 결과를 반환한다', async () => {
+    const prevGoogleKey = process.env.GOOGLE_MAPS_API_KEY;
+    process.env.GOOGLE_MAPS_API_KEY = 'test-google-key';
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'OK',
+            results: [{ geometry: { location: { lat: 37.4979, lng: 127.0276 } } }],
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ stores: [] })))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            SearchQueryResult: {
+              Collection: [
+                {
+                  Documentset: {
+                    Document: [{ field: { itemCode: '8801117752804', itemName: '오감자' } }],
+                  },
+                },
+              ],
+            },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ stores: [] })));
+
+    const tool = createFindNearbyStoresTool();
+    const result = await tool.handler({ keyword: '강남', limit: 3 });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.fallbackUsed).toBe(false);
+    expect(parsed.count).toBe(0);
+
+    process.env.GOOGLE_MAPS_API_KEY = prevGoogleKey;
+  });
 });

--- a/tests/services/lottemart/tools/findNearbyStores.test.ts
+++ b/tests/services/lottemart/tools/findNearbyStores.test.ts
@@ -8,6 +8,18 @@ import { createFindNearbyStoresTool } from '../../../../src/services/lottemart/t
 
 const mockFetch = vi.fn();
 const createSessionResponse = () => new Response('', { headers: { 'set-cookie': 'ASPSESSIONID=TEST; path=/' } });
+const createZyteResponse = (bodyText: string) =>
+  new Response(
+    JSON.stringify({
+      statusCode: 200,
+      httpResponseBody: Buffer.from(bodyText, 'utf8').toString('base64'),
+    }),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
 
 beforeEach(() => {
   mockFetch.mockReset();
@@ -121,5 +133,40 @@ describe('createFindNearbyStoresTool', () => {
     expect(parsed.area).toBeNull();
     expect(parsed.brandVariant).toBeNull();
     expect(parsed.count).toBe(1);
+  });
+
+  it('기본 Zyte 키로 직접 매장 조회 실패를 우회한다', async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response('origin timeout', { status: 522, statusText: 'Origin Timeout' }))
+      .mockResolvedValueOnce(
+        createZyteResponse(`
+          <section class="sub-wrap result-shop-list">
+            <ul class="list-result">
+              <li>
+                <div class="shop-tit">잠실점</div>
+                <div class="shop-desc">
+                  <ul>
+                    <li><span>주소 : </span> 서울 송파구 올림픽로 240</li>
+                    <li><span>상담전화 : </span><a onclick="goClick('2301');">02-411-8025</a></li>
+                  </ul>
+                </div>
+                <a class="link" href="./detail_shop.asp?werks=2301"></a>
+              </li>
+            </ul>
+          </section>
+        `),
+      );
+
+    const tool = createFindNearbyStoresTool(undefined, 'test-zyte-key');
+    const result = await tool.handler({
+      area: '서울',
+      keyword: '잠실',
+      limit: 1,
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.count).toBe(1);
+    expect(parsed.stores[0].storeName).toBe('잠실점');
+    expect(String(mockFetch.mock.calls[1]?.[0])).toBe('https://api.zyte.com/v1/extract');
   });
 });

--- a/tests/services/lottemart/tools/searchProducts.test.ts
+++ b/tests/services/lottemart/tools/searchProducts.test.ts
@@ -8,6 +8,18 @@ import { createSearchProductsTool } from '../../../../src/services/lottemart/too
 
 const mockFetch = vi.fn();
 const createSessionResponse = () => new Response('', { headers: { 'set-cookie': 'ASPSESSIONID=TEST; path=/' } });
+const createZyteResponse = (bodyText: string) =>
+  new Response(
+    JSON.stringify({
+      statusCode: 200,
+      httpResponseBody: Buffer.from(bodyText, 'utf8').toString('base64'),
+    }),
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
 
 beforeEach(() => {
   mockFetch.mockReset();
@@ -68,5 +80,30 @@ describe('createSearchProductsTool', () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.totalCount).toBe(1);
     expect(parsed.products[0].productName).toBe('코카콜라');
+  });
+
+  it('기본 Zyte 키로 직접 매장 옵션 조회 실패를 우회한다', async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response('origin timeout', { status: 522, statusText: 'Origin Timeout' }))
+      .mockResolvedValueOnce(createZyteResponse('<option value="2301">강변점</option>'))
+      .mockResolvedValueOnce(
+        new Response(`
+          <!doctype html>
+          <div class="total-num">검색결과 : <span>0</span>건</div>
+          <script>var totalPage = "1";</script>
+          <ul class="list-result"></ul>
+        `),
+      );
+
+    const tool = createSearchProductsTool('test-zyte-key');
+    const result = await tool.handler({
+      area: '서울',
+      storeCode: '2301',
+      keyword: '콜라',
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.storeCode).toBe('2301');
+    expect(String(mockFetch.mock.calls[1]?.[0])).toBe('https://api.zyte.com/v1/extract');
   });
 });


### PR DESCRIPTION
## Summary
- add a GS25 store-search fallback that uses stock lookup when coordinate store search comes back empty
- pass the deployed Zyte API key through LotteMart API handlers and MCP tools
- cover the GS25 fallback and LotteMart default Zyte fallback paths in tests

## Verification
- npm run format:check
- npm run lint
- npm run typecheck
- npm run build
- npx vitest run tests/services/gs25/tools/findNearbyStores.test.ts tests/services/lottemart/tools/findNearbyStores.test.ts tests/services/lottemart/tools/searchProducts.test.ts tests/api/gs25-handlers.test.ts tests/api/lottemart-handlers.test.ts
- npx vitest run tests/app/app-api-lottemart.test.ts tests/app/app-api-gs25.test.ts --testTimeout=30000
- npx vitest run --testTimeout=30000 --hookTimeout=30000

Refs #45, #46