### PR TITLE
fix: Zyte 평문 520 오류 처리

### DIFF
--- a/src/api/configStatus.ts
+++ b/src/api/configStatus.ts
@@ -26,7 +26,7 @@ export function buildConfigStatus(bindings?: AppBindings): ConfigStatus {
     },
     zyteApiKey: {
       configured: isConfigured(bindings?.ZYTE_API_KEY),
-      usedBy: ['oliveyoung', 'gs25', 'lottemart', 'cgv'],
+      usedBy: ['oliveyoung', 'gs25', 'cu', 'seveneleven', 'lottemart', 'cgv'],
     },
     naverLocalSearch: {
       configured:

--- a/src/utils/zyte.ts
+++ b/src/utils/zyte.ts
@@ -85,6 +85,16 @@ function isRetryableError(error: unknown): boolean {
   return isAbortError(error) || error instanceof RetryableZyteError;
 }
 
+function parseZyteResponseBody(text: string): ZyteExtractResponse {
+  try {
+    return JSON.parse(text) as ZyteExtractResponse;
+  } catch {
+    return {
+      detail: text.trim().replace(/\s+/g, ' ').slice(0, 300),
+    };
+  }
+}
+
 function wait(ms: number): Promise<void> {
   if (ms <= 0) {
     return Promise.resolve();
@@ -139,7 +149,7 @@ export async function requestByZyte(options: ZyteExtractOptions): Promise<ZyteEx
         throw error;
       }
 
-      const result = (await response.json()) as ZyteExtractResponse;
+      const result = parseZyteResponseBody(await response.text());
 
       if (!response.ok) {
         const message = `Zyte API 호출 실패: ${response.status} ${result.detail || result.title || ''}`.trim();

--- a/tests/app/app-info-pages.test.ts
+++ b/tests/app/app-info-pages.test.ts
@@ -294,7 +294,10 @@ describe('기본 페이지', () => {
     expect(data.status).toBe('ok');
     expect(data.config).toEqual({
       googleMapsApiKey: { configured: true, usedBy: expect.arrayContaining(['gs25', 'cgv']) },
-      zyteApiKey: { configured: false, usedBy: expect.arrayContaining(['oliveyoung', 'cgv']) },
+      zyteApiKey: {
+        configured: false,
+        usedBy: expect.arrayContaining(['oliveyoung', 'cgv', 'cu', 'seveneleven']),
+      },
       naverLocalSearch: { configured: false, usedBy: ['places'] },
       opinetApiKey: { configured: false, usedBy: ['opinet'] },
       supabaseFeedback: { configured: false, usedBy: ['feedback'] },

--- a/tests/services/cu/client.test.ts
+++ b/tests/services/cu/client.test.ts
@@ -504,6 +504,26 @@ describe('fetchCuStock', () => {
     });
   });
 
+  it('Zyte가 평문 HTTP 520을 반환해도 재고를 unavailable로 반환한다', async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify({ areaList: [] })))
+      .mockResolvedValueOnce(new Response('blocked', { status: 403 }))
+      .mockResolvedValueOnce(new Response('error code: 520', { status: 520 }));
+
+    const result = await fetchCuStock(
+      { keyword: '과자', limit: 1, offset: 0, searchSort: 'recom' },
+      { apiKey: 'test-key' },
+    );
+
+    expect(result).toEqual({
+      available: false,
+      unavailableReason: expect.stringContaining('Website Ban'),
+      totalCount: 0,
+      spellModifyYn: 'N',
+      items: [],
+    });
+  });
+
   it('Zyte 키 없이 원본 재고가 차단되어도 unavailable로 반환한다', async () => {
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify({ areaList: [] })))

--- a/tests/services/oliveyoung/client.test.ts
+++ b/tests/services/oliveyoung/client.test.ts
@@ -19,6 +19,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
   delete process.env.ZYTE_API_KEY;
 });
@@ -600,10 +601,11 @@ describe('fetchOliveyoungProducts', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({
-        statusCode: 200,
-        httpResponseBody: encodedBody,
-      }),
+      text: async () =>
+        JSON.stringify({
+          statusCode: 200,
+          httpResponseBody: encodedBody,
+        }),
     });
 
     await expect(

--- a/tests/utils/zyte.test.ts
+++ b/tests/utils/zyte.test.ts
@@ -62,6 +62,20 @@ describe('requestByZyte', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
+  it('Zyte API가 평문 520 오류를 반환해도 상태와 본문을 보존한다', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('error code: 520', { status: 520 }));
+
+    await expect(
+      requestByZyte({
+        apiKey: 'test-key',
+        url: 'https://example.com/api',
+        retries: 0,
+      }),
+    ).rejects.toThrow('Zyte API 호출 실패: 520 error code: 520');
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('대상 사이트 5xx 응답이면 한 번 재시도한다', async () => {
     mockFetch
       .mockResolvedValueOnce(new Response(JSON.stringify({ statusCode: 520, httpResponseBody: 'e30=' })))


### PR DESCRIPTION
## 요약
- Zyte가 JSON이 아닌 평문 HTTP 520을 반환해도 상태와 짧은 본문을 보존해 진단 가능한 오류로 변환합니다.
- CU 재고는 이 응답을 `available: false` degraded 성공으로 처리해 HTTP 500 연결 끊김을 방지합니다.
- `/health`의 Zyte 사용처에 CU와 세븐일레븐을 정확히 표시합니다.
- 전역 `Buffer`/`atob` 테스트 stub이 실패 후 다른 테스트를 오염시키지 않도록 격리합니다.

## 검증
- `npm run format:check`
- `npm run lint`
- `npm run lint:biome`
- `npm run typecheck`
- `npm run check:source-lines`
- `npx vitest run --maxWorkers=1 --no-file-parallelism` (143 files, 1,619 tests)
- `npx vitest run --coverage --maxWorkers=1 --no-file-parallelism` (100% statements/branches/functions/lines)
- `npm run build`

## 운영 재현
배포 후 CU 재고 호출에서 Zyte가 평문 `error code: 520`을 반환해 기존 버전이 500을 냈으며, 이 응답 형태를 회귀 테스트로 추가했습니다.